### PR TITLE
add `metadata`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Behold! a Poor man's [DAP Registry](https://github.com/TBD54566975/dap?tab=readm
 # "Registering" a DAP
 1. Clone this repo
 2. Activate hermit
-3. run `just register <your_handle>
+3. run `just register <your_handle>`
 4. add whatever money addresses you want
 
 

--- a/registry/metadata
+++ b/registry/metadata
@@ -1,0 +1,5 @@
+{
+  "registration": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Added `metadata` to `registry` dir to support [this part](https://github.com/TBD54566975/dap?tab=readme-ov-file#metadata) of the DAP spec