### PR TITLE
register nonni

### DIFF
--- a/register/main.go
+++ b/register/main.go
@@ -31,6 +31,7 @@ func main() {
 		return
 	}
 
+	input = strings.TrimSuffix(input, "\n")
 	maddrs := strings.Split(input, ",")
 	maddrServices := make([]didweb.CreateOption, len(maddrs))
 

--- a/registry/daps/nonni
+++ b/registry/daps/nonni
@@ -1,0 +1,10 @@
+{
+  "did": "did:web:didpay.me:nonni",
+  "proof": {
+    "id": "reg_01j1e3fh42f2j8b4y154en8h1d",
+    "handle": "nonni",
+    "did": "did:web:didpay.me:nonni",
+    "domain": "didpay.me",
+    "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZGlkcGF5Lm1lOm5vbm5pIzAifQ..YLvAVw4TVkeIjSwq0l-UsR7MYFSB2t1VdyHQwKwOvqDde9FMS4oZhp2iRO9n16grenU2N4zMmfMF_MSTaDqjDw"
+  }
+}

--- a/registry/nonni/did.json
+++ b/registry/nonni/did.json
@@ -1,0 +1,31 @@
+{
+  "id": "did:web:didpay.me:nonni",
+  "verificationMethod": [
+    {
+      "id": "did:web:didpay.me:nonni#0",
+      "type": "JsonWebKey",
+      "controller": "did:web:didpay.me:nonni",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "CdQSOxXMPpXBCBaov41bYAp6jcoceGRqDIknl7SQQP0"
+      }
+    }
+  ],
+  "service": [
+    {
+      "id": "#0",
+      "type": "MoneyAddress",
+      "serviceEndpoint": [
+        "urn:btc:addr:bc1qwca40hqmmcl4pntrwfd2v73lggxawdsazs06uk4520lx9exp7f9qsyulp8"
+      ]
+    },
+    {
+      "id": "#1",
+      "type": "MoneyAddress",
+      "serviceEndpoint": [
+        "urn:btc:lnaddr:nonni@atlbitlab.com"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
1. register `did:web:didpay.me:nonni`
2. fix small bug; kept getting a newline char at the end of the second DAP, e.g.
```
{
      "id": "#1",
      "type": "MoneyAddress",
      "serviceEndpoint": [
        "urn:btc:lnaddr:nonni@atlbitlab.com\n"
      ]
}
```